### PR TITLE
Added configuration option for hiding introspection query

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ If you want to change this behaviour, add `config/initializes/graphql_logger.rb`
   }
 ```
 
+## Configuration
+
+There is an option to suppress (hide) the GraphQL Introspection Query from the console output. This may be helpful to declutter the console during client testing as these can be rather lengthy.
+
+`config/initializers/graphql_rails_logger.rb`
+
+```ruby
+GraphQL::RailsLogger.configure do |config|
+  config.skip_introspection_query = true
+end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jetruby/graphql-rails_logger. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/graphql/rails_logger/configuration.rb
+++ b/lib/graphql/rails_logger/configuration.rb
@@ -1,0 +1,10 @@
+module GraphQL
+  module RailsLogger
+    class Configuration
+      attr_accessor :skip_introspection_query
+      def initialize
+        @skip_introspection_query = nil
+      end
+    end
+  end
+end

--- a/lib/graphql/rails_logger/subscriber.rb
+++ b/lib/graphql/rails_logger/subscriber.rb
@@ -1,8 +1,21 @@
+require 'graphql/rails_logger/configuration'
 require 'action_controller/log_subscriber'
 require 'rouge'
 
 module GraphQL
   module RailsLogger
+    class << self
+      attr_accessor :configuration
+    end
+
+    def self.configuration
+      @configuration ||= Configuration.new
+    end
+
+    def self.configure
+      yield(configuration)
+    end
+
     class Subscriber < ActionController::LogSubscriber
       def start_processing(event)
         return unless logger.info?
@@ -12,6 +25,8 @@ module GraphQL
         format  = payload[:format]
         format  = format.to_s.upcase if format.is_a?(Symbol)
 
+        config = GraphQL::RailsLogger.configuration
+
         info "Processing by #{payload[:controller]}##{payload[:action]} as #{format}"
 
         if Rails.application.config.graphql_logger.fetch(payload[:controller], []).include?(payload[:action])
@@ -20,6 +35,9 @@ module GraphQL
           variables_lexer = Rouge::Lexers::Ruby.new
 
           (params['_json'] || [params.slice('query', 'variables')]).each do |data|
+
+            next if config.skip_introspection_query && data['query'].index(/query IntrospectionQuery/)
+
             query = data['query'].lines.map { |line| "  #{line}" }.join.chomp # add indentation
             variables = PP.pp(data['variables'] || {}, '')
             info "  Variables: #{formatter.format(variables_lexer.lex(variables))}"


### PR DESCRIPTION
This is a quick implementation for skipping the Introspection Query #1 

This simply skips the query based on a regex of the query string.