### PR TITLE
Strip down dependencies of rails

### DIFF
--- a/graphql-rails_logger.gemspec
+++ b/graphql-rails_logger.gemspec
@@ -21,7 +21,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rouge', '~> 3.0'
-  spec.add_dependency 'rails', '~> 5.0' # 5 because not tested with 4
+
+  # 5 because not tested with 4
+  spec.add_dependency 'actionpack', '~> 5.0'
+  spec.add_dependency 'activesupport', '~> 5.0'
+  spec.add_dependency 'railties', '~> 5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/graphql/rails_logger/version.rb
+++ b/lib/graphql/rails_logger/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module RailsLogger
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end


### PR DESCRIPTION
Hi!

Thanks for this gem, I really like it. I had to change the gemspec to fit my app which uses only some gems of rails and not the full pack.

This is a simple change to use only the required parts of rails that this gem needs, so it keeps the same behaviour but allows to use in apps that have only actionpack/support for example (thus not installing extra gems  without need)

I think it can be useful for more people in the same situation that I am.

What do you think?