### PR TITLE
Support Rails 6 by loosening fixed Rails dependencies

### DIFF
--- a/graphql-rails_logger.gemspec
+++ b/graphql-rails_logger.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rouge', '~> 3.0'
 
   # 5 because not tested with 4
-  spec.add_dependency 'actionpack', '~> 5.0'
-  spec.add_dependency 'activesupport', '~> 5.0'
-  spec.add_dependency 'railties', '~> 5.0'
+  spec.add_dependency 'actionpack', '> 5.0'
+  spec.add_dependency 'activesupport', '> 5.0'
+  spec.add_dependency 'railties', '> 5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Hi 👋, thanks for this great gem, it's made using graphql-ruby much nicer. 👍

Currently the gemspec is locked to `~> 5.0` mentioning "because it's not tested with Rails 4." Rails 6 just came out, and this is our last blocker gem. I forked it and allowed any version greater than 5. It works perfectly fine with Rails 6, which is nice. Let me know if you need anything from me to get this merged and launched.

Thank you!