### PR TITLE
Fix uninitialized constant PP

### DIFF
--- a/lib/graphql/rails_logger/subscriber.rb
+++ b/lib/graphql/rails_logger/subscriber.rb
@@ -1,6 +1,7 @@
 require 'graphql/rails_logger/configuration'
 require 'action_controller/log_subscriber'
 require 'rouge'
+require 'pp'
 
 module GraphQL
   module RailsLogger


### PR DESCRIPTION
 NameError: uninitialized constant GraphQL::RailsLogger::Subscriber::PP

Rails 6 & Ruby 2.6.4