### PR TITLE
Hide publishing `bin` executables

### DIFF
--- a/graphql-rails_logger.gemspec
+++ b/graphql-rails_logger.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = 'bin'
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rouge', '~> 3.0'


### PR DESCRIPTION
After installing this gem, I realized that `console` and `setup` became registered shell commands, binding to this gem's `bin/` directory scripts.

This PR should fix that.
