### PR TITLE
Fix logging requests with an empty query

### DIFF
--- a/lib/graphql/rails_logger/subscriber.rb
+++ b/lib/graphql/rails_logger/subscriber.rb
@@ -37,7 +37,7 @@ module GraphQL
 
           (params['_json'] || [params.slice('query', 'variables', 'extensions')]).each do |data|
 
-            next if config.skip_introspection_query && data['query'].index(/query IntrospectionQuery/)
+            next if config.skip_introspection_query && data['query']&.index(/query IntrospectionQuery/)
 
             # Cleanup and indent params for logging
             query = indent(data.fetch('query', ''))


### PR DESCRIPTION
With the persisted query approach client can send only the hash key without `query` params like:
```
Extensions:
  {"persistedQuery"=>
    {"version"=>1,
     "sha256Hash"=>
      "a0ea5cea007086d686535c9a52f433cfecd8ca4bd516d5bbf4d7c64fd5d52dfd"}}
``` 
In this case, it will fail to log with the error:
```
Could not log "start_processing.action_controller" event. NoMethodError: undefined method `index' for nil:NilClass ["/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/graphql-rails_logger-1.2.3/lib/graphql/rails_logger/subscriber.rb:40:in `block in start_processing'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/graphql-rails_logger-1.2.3/lib/graphql/rails_logger/subscriber.rb:38:in `each'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/graphql-rails_logger-1.2.3/lib/graphql/rails_logger/subscriber.rb:38:in `start_processing'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/subscriber.rb:145:in `finish'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/log_subscriber.rb:107:in `finish'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications/fanout.rb:160:in `finish'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications/fanout.rb:62:in `block in finish'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications/fanout.rb:62:in `each'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications/fanout.rb:62:in `finish'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications/instrumenter.rb:45:in `finish_with_state'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications/instrumenter.rb:30:in `instrument'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/notifications.rb:180:in `instrument'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_controller/metal/instrumentation.rb:30:in `process_action'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_controller/metal/params_wrapper.rb:245:in `process_action'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activerecord-6.0.4.4/lib/active_record/railties/controller_runtime.rb:27:in `process_action'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/abstract_controller/base.rb:136:in `process'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionview-6.0.4.4/lib/action_view/rendering.rb:39:in `process'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_controller/metal.rb:190:in `dispatch'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_controller/metal.rb:254:in `dispatch'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/routing/route_set.rb:33:in `serve'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/journey/router.rb:49:in `block in serve'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/journey/router.rb:32:in `each'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/journey/router.rb:32:in `serve'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/routing/route_set.rb:834:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-pjax-1.1.0/lib/rack/pjax.rb:12:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/bullet-6.1.4/lib/bullet/rack.rb:15:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-proxy-0.6.5/lib/rack/proxy.rb:57:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/omniauth-1.9.1/lib/omniauth/builder.rb:45:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/rack/agent_hooks.rb:30:in `traced_call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/rack/browser_monitoring.rb:33:in `traced_call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/warden-jwt_auth-0.5.0/lib/warden/jwt_auth/middleware/token_dispatcher.rb:20:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/warden-jwt_auth-0.5.0/lib/warden/jwt_auth/middleware/revocation_manager.rb:21:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/builder.rb:244:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/warden-jwt_auth-0.5.0/lib/warden/jwt_auth/middleware.rb:23:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/remotipart-1.4.4/lib/remotipart/middleware.rb:32:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:36:in `block in call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `catch'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/tempfile_reaper.rb:15:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/etag.rb:27:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/conditional_get.rb:40:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/head.rb:12:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/http/content_security_policy.rb:18:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/session/abstract/id.rb:266:in `context'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/session/abstract/id.rb:260:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/cookies.rb:654:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activerecord-6.0.4.4/lib/active_record/migration.rb:567:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/callbacks.rb:101:in `run_callbacks'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/callbacks.rb:26:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/executor.rb:14:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sentry-rails-4.7.3/lib/sentry/rails/rescued_exception_interceptor.rb:12:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/better_errors-2.9.1/lib/better_errors/middleware.rb:87:in `protected_app_call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/better_errors-2.9.1/lib/better_errors/middleware.rb:82:in `better_errors_call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/better_errors-2.9.1/lib/better_errors/middleware.rb:60:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/debug_exceptions.rb:32:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/web-console-4.1.0/lib/web_console/middleware.rb:132:in `call_app'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/web-console-4.1.0/lib/web_console/middleware.rb:28:in `block in call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/web-console-4.1.0/lib/web_console/middleware.rb:17:in `catch'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/web-console-4.1.0/lib/web_console/middleware.rb:17:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/railties-6.0.4.4/lib/rails/rack/logger.rb:37:in `call_app'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/railties-6.0.4.4/lib/rails/rack/logger.rb:26:in `block in call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/tagged_logging.rb:80:in `block in tagged'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/tagged_logging.rb:28:in `tagged'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/tagged_logging.rb:80:in `tagged'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/railties-6.0.4.4/lib/rails/rack/logger.rb:26:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/ahoy_matey-3.0.5/lib/ahoy/engine.rb:22:in `call_with_quiet_ahoy'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:13:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/request_store-1.5.1/lib/request_store/middleware.rb:19:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/request_id.rb:27:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.4/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sentry-ruby-core-4.7.3/lib/sentry/rack/capture_exceptions.rb:23:in `block in call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sentry-ruby-core-4.7.3/lib/sentry/hub.rb:56:in `with_scope'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sentry-ruby-core-4.7.3/lib/sentry-ruby.rb:176:in `with_scope'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sentry-ruby-core-4.7.3/lib/sentry/rack/capture_exceptions.rb:14:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/executor.rb:14:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/static.rb:126:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/active_storage_silent_logs-0.1.2/lib/active_storage_silent_logs/silent_logger.rb:17:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4.4/lib/action_dispatch/middleware/host_authorization.rb:103:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/railties-6.0.4.4/lib/rails/engine.rb:527:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/newrelic_rpm-8.9.0/lib/new_relic/agent/instrumentation/middleware_tracing.rb:100:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/puma-5.6.4/lib/puma/configuration.rb:252:in `call'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/puma-5.6.4/lib/puma/request.rb:77:in `block in handle_request'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:340:in `with_force_shutdown'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/puma-5.6.4/lib/puma/request.rb:76:in `handle_request'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/puma-5.6.4/lib/puma/server.rb:441:in `process_client'"
"/Users/vad4msiu/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:147:in `block in spawn_thread'"]
```